### PR TITLE
Add rule for line-height

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
     "color-hex-length": "short",
     "color-named": "never",
     "color-no-invalid-hex": true,
+    "declaration-property-unit-whitelist": { "line-height": [] },
     "font-family-name-quotes": "always-where-recommended",
     "font-family-no-duplicate-names": true,
     "font-weight-notation": "numeric",


### PR DESCRIPTION
The recommended method for defining line height is using a number value, referred to as a "unitless" line height. A number value can be any number, including a decimal-based number, as is used in the first code example on this page.

Unitless line heights are recommended due to the fact that child elements will inherit the raw number value, rather than the computed value. With this, child elements can compute their line heights based on their computed font size, rather than inheriting an arbitrary value from a parent that is more likely to need overriding.

Source: https://css-tricks.com/almanac/properties/l/line-height/