### PR TITLE
Adds transparent as an ignored keyword for strict value

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,8 @@ module.exports = {
         ignoreKeywords: [
           'currentColor',
           'inherit',
-          'initial'
+          'initial',
+          'transparent'
         ]
       }
     ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-punkave",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "index.js",
   "author": "P'unk Ave",
   "repository": {


### PR DESCRIPTION
https://github.com/punkave/stylelint-config-punkave/blob/5feb44b60b3a43bae9967b5fab2ff8cf8950f5b5/index.js#L78

That line is throwing an error for this: `border-color: color(brand-blue) transparent transparent;`, which is different from a normal color declaration. I thought it should be in with other ignored keywords.