### PR TITLE
Removes font-weight notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,8 @@ Add the following to `.stylelintrc` in root directory of project.
 ```
 
 ## Changelog
+### 1.1.0
+- Rules eased, removing the font-weight rule due to our practice of using a Sass function for the property.
+
 ### 1.0.0
 - Adds "declaration-strict-value," setting rules for variable use in specific properties.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = {
     'color-no-invalid-hex': true,
     'declaration-property-unit-whitelist': { 'line-height': [] },
     'font-family-no-duplicate-names': true,
-    'font-weight-notation': 'numeric',
     'number-leading-zero': 'always',
     'number-max-precision': 2,
     'number-no-trailing-zeros': true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-punkave",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "author": "P'unk Ave",
   "repository": {


### PR DESCRIPTION
If we're using a weight function then we shouldn't be expecting numeric here.